### PR TITLE
add features to profile dyn behavior

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,6 @@
 useDynLib(dynamismtracer, .registration = TRUE, .fixes = "C_")
 exportPattern("^[[:alpha:]]+")
 import(dynalyzer)
+import(magrittr)
+import(dplyr)
+import(stringr)

--- a/R/analysis.R
+++ b/R/analysis.R
@@ -1,4 +1,5 @@
 #' @export
 get_analysis_group <- function() {
-    group_analyses(function_definitions_analysis)
+    group_analyses(function_definitions_analysis,
+		   dynamic_calls_analysis)
 }

--- a/R/dynamic_calls.R
+++ b/R/dynamic_calls.R
@@ -1,0 +1,38 @@
+dynamic_calls_analysis <- create_analysis(
+
+    id = "dynamic_calls",
+
+    reducer = function(analyses) {
+
+        if(nrow(analyses$dyn_behavior) == 0) {
+            return(list())
+        }
+
+        list(dyn_behavior = analyses$dyn_behavior)
+    },
+
+    summarizer = function(analyses) {
+
+        encode_sequence <- function(seq) {
+            str_c("(", str_c(seq, collapse = " "), ")", sep = "")
+        }
+
+        decode_sequence <- function(seq) {
+            unlist(str_split(str_sub(seq, 2, -2), " "))
+        }
+
+        dynamic_calls <-
+            analyses$dyn_behavior %>%
+            group_by(function_id) %>%
+            summarize(formal_parameter_count = first(formal_parameter_count),
+		      dyn_call_count = sum(dyn_call_count),
+		      call_count = sum(call_count),
+                      package = first(package),
+                      function_name = encode_sequence(unique(decode_sequence(function_name))),
+                      script = encode_sequence(str_c(package, script_type, script_name,
+                                                     sep = "/"))) %>%
+            ungroup()
+
+        list(dynamic_calls = dynamic_calls)
+    }
+)

--- a/src/Call.cpp
+++ b/src/Call.cpp
@@ -17,7 +17,7 @@ Call::Call(const call_id_t id,
     , jumped_(false)
     , S3_method_(false)
     , S4_method_(false)
-    , call_as_arg_(0)
+    , dyn_call_(false)
     , callee_counter_(0) {
     wrapper_ = function_->is_dot_internal() || function_->is_dot_primitive() ||
                function_->is_dot_c() || function_->is_dot_fortran() ||

--- a/src/Call.h
+++ b/src/Call.h
@@ -23,59 +23,6 @@ class Call {
         return id_;
     }
 
-    void process_calls_affecting_lookup() {
-        // std::string fn_id = compute_hash((get_function() -> get_namespace() +
-        // get_function() -> get_definition()).c_str()); Function* fn =
-        // get_function(); fn->is_byte_compiled();
-        // <<- is a special, we have to access its arguments in a specific way
-        if (function_name_.compare("<<-") == 0) {
-            if (value_type_to_string(CAR(CDR(args_)))
-                    .compare("Function Call") == 0) {
-                set_call_as_arg(1);
-            } else {
-                set_call_as_arg(0);
-            }
-
-        }
-        // assign and with are closures
-        else if ((function_name_.compare("assign") == 0)) {
-            Argument* arg = get_argument(1);
-            DenotedValue* value = arg->get_denoted_value();
-            std::string expression_type =
-                sexptype_to_string(value->get_expression_type());
-
-            if (expression_type.compare("Function Call") == 0) {
-                set_call_as_arg(1);
-            } else {
-                set_call_as_arg(0);
-            }
-        } else if ((function_name_.compare("with") == 0)) {
-            Argument* arg = get_argument(1);
-            DenotedValue* value = arg->get_denoted_value();
-            std::string expression_type =
-                sexptype_to_string(value->get_expression_type());
-
-            if (expression_type.compare("Function Call") == 0) {
-                set_call_as_arg(1);
-            } else {
-                set_call_as_arg(0);
-            }
-        } else if ((function_name_.compare("mamahu") == 0)) {
-            Argument* arg = get_argument(1);
-            DenotedValue* value = arg->get_denoted_value();
-            std::string expression_type =
-                sexptype_to_string(value->get_expression_type());
-
-            if (expression_type.compare("Function Call") == 0) {
-                set_call_as_arg(1);
-            } else {
-                set_call_as_arg(0);
-            }
-        } else {
-            set_call_as_arg(0);
-        }
-    }
-
     SEXP get_args() {
         return args_;
     }
@@ -96,12 +43,12 @@ class Call {
         return actual_argument_count_;
     }
 
-    void set_call_as_arg(int nr) {
-        call_as_arg_ = nr;
+    void set_dyn_call() {
+        dyn_call_ = true;
     }
 
-    int get_call_as_arg() const {
-        return call_as_arg_;
+    bool is_dyn_call() const {
+        return dyn_call_;
     }
 
     SEXP get_environment() const {
@@ -215,7 +162,7 @@ class Call {
     bool S3_method_;
     bool S4_method_;
     int callee_counter_;
-    int call_as_arg_;
+    bool dyn_call_;
     bool wrapper_;
     std::vector<Argument*> arguments_;
     pos_seq_t force_order_;

--- a/src/CallSummary.h
+++ b/src/CallSummary.h
@@ -13,7 +13,7 @@ class CallSummary {
         S3_method_ = call->is_S3_method();
         S4_method_ = call->is_S4_method();
         call_count_ = 1;
-        call_arg_count_ = call->get_call_as_arg();
+        dyn_call_count_ = 0;
     }
 
     const pos_seq_t& get_force_order() const {
@@ -44,14 +44,16 @@ class CallSummary {
         return call_count_;
     }
 
-    int get_call_arg_count() const {
-        return call_arg_count_;
+    int get_dyn_call_count() const {
+        return dyn_call_count_;
     }
 
     bool try_to_merge(const Call* const call) {
         if (is_mergeable_(call)) {
             call_count_++;
-            call_arg_count_ = call_arg_count_ + call->get_call_as_arg();
+            if (call->is_dyn_call()) {
+                dyn_call_count_++;
+            }
             return true;
         }
         return false;
@@ -65,7 +67,7 @@ class CallSummary {
     bool S3_method_;
     bool S4_method_;
     int call_count_;
-    int call_arg_count_;
+    int dyn_call_count_;
 
     bool is_mergeable_(const Call* const call) const {
         return (get_force_order() == call->get_force_order() &&

--- a/src/TracerState.h
+++ b/src/TracerState.h
@@ -1069,19 +1069,21 @@ class TracerState {
                                  const std::string& names) {
         for (std::size_t i = 0; i < function->get_summary_count(); ++i) {
             const CallSummary& call_summary = function->get_call_summary(i);
-
-            dyn_behavior_data_table_->write_row(
-                function->get_id(),
-                function->get_namespace(),
-                names,
-                sexptype_to_string(function->get_type()),
-                function->get_formal_parameter_count(),
-                call_summary.is_S3_method(),
-                call_summary.is_S4_method(),
-                sexptype_to_string(call_summary.get_return_value_type()),
-                call_summary.get_call_count(),
-                call_summary.get_dyn_call_count());
-        }
+	    
+	    if (call_summary.get_dyn_call_count() > 0) {
+            	dyn_behavior_data_table_->write_row(
+                	function->get_id(),
+                	function->get_namespace(),
+                	names,
+                	sexptype_to_string(function->get_type()),
+                	function->get_formal_parameter_count(),
+                	call_summary.is_S3_method(),
+                	call_summary.is_S4_method(),
+                	sexptype_to_string(call_summary.get_return_value_type()),
+                	call_summary.get_call_count(),
+                	call_summary.get_dyn_call_count());
+        	}
+	}
     }
 
     void serialize_function_call_summary_(const Function* function,

--- a/src/TracerState.h
+++ b/src/TracerState.h
@@ -68,11 +68,26 @@ class TracerState {
              "missing_arguments",
              "return_value_type",
              "jumped",
-             "call_count",
-             "call_arg_count"},
+             "call_count"},
             truncate_,
             binary_,
             compression_level_);
+
+        dyn_behavior_data_table_ = dynalyzer_create_data_table(
+						output_dirpath_ + "/" + "dyn_behavior",
+	          {"function_id",
+	           "package",
+	           "function_name",
+	           "function_type",
+	           "formal_parameter_count",
+	           "S3_method",
+	           "S4_method",
+	           "return_value_type",
+	           "call_count",
+	           "dyn_call_count"},
+	          truncate_,
+	          binary_,
+	          compression_level_);
 
         function_definitions_data_table_ = dynalyzer_create_data_table(
             output_dirpath_ + "/" + "function_definitions",
@@ -249,6 +264,7 @@ class TracerState {
         delete event_counts_data_table_;
         delete object_counts_data_table_;
         delete call_summaries_data_table_;
+        delete dyn_behavior_data_table_;
         delete function_definitions_data_table_;
         delete arguments_data_table_;
         delete side_effects_data_table_;
@@ -771,7 +787,6 @@ class TracerState {
             int eval = dyntrace_get_c_function_argument_evaluation(op);
             function_call->set_force_order(eval);
         }
-        function_call->process_calls_affecting_lookup();
         return function_call;
     }
 
@@ -991,6 +1006,46 @@ class TracerState {
         }
     }
 
+    void update_dyn_call_counter(sexptype_t expression_type,
+                                 SEXP param,
+                                 Call* fn_call) {
+        if (expression_type == LANGSXP) {
+            std::string sym_name = CHAR(PRINTNAME(CAR(param)));
+            if (sym_name.compare("function") == 0) {
+                fn_call->set_dyn_call();
+            }
+        } else if (expression_type == SYMSXP) {
+            // TODO- needs a hook
+            // this symbol could potentially point to a function. We need to
+            // inspect the environment to know
+        }
+    }
+
+    void process_dynamic_calls_for_closures(std::string fn_name,
+                                            Call* fn_call,
+                                            int arg_index) {
+        Argument* arg = fn_call->get_argument(arg_index);
+        DenotedValue* value = arg->get_denoted_value();
+        SEXP expr = value->get_expression();
+        sexptype_t expression_type = type_of_sexp(expr);
+
+        update_dyn_call_counter(expression_type, expr, fn_call);
+    }
+
+    /* f <<- 1+2
+     * op is <<-
+     * CAR(args) is the symbol f
+     * CDR(args) is a pairlist, whose 1st value is a function call - OLD
+     */
+    void process_dynamic_calls_for_specials(Call* fn_call) {
+        SEXP fn_args = fn_call->get_args();
+        SEXP right_param = CADR(fn_args); // first element of the object pointed
+                                          // by the right parameter of <<-
+        sexptype_t expression_type = type_of_sexp(right_param);
+
+        update_dyn_call_counter(expression_type, right_param, fn_call);
+    }
+
   private:
     void destroy_function_(Function* function) {
         serialize_function_(function);
@@ -998,6 +1053,7 @@ class TracerState {
     }
 
     DataTableStream* call_summaries_data_table_;
+    DataTableStream* dyn_behavior_data_table_;
     DataTableStream* function_definitions_data_table_;
     std::unordered_map<SEXP, Function*> functions_;
     std::unordered_map<function_id_t, Function*> function_cache_;
@@ -1006,6 +1062,26 @@ class TracerState {
         const std::string all_names = function->get_name_string();
         serialize_function_call_summary_(function, all_names);
         serialize_function_definition_(function, all_names);
+        serialize_dyn_behavior_(function, all_names);
+    }
+
+    void serialize_dyn_behavior_(const Function* function,
+                                 const std::string& names) {
+        for (std::size_t i = 0; i < function->get_summary_count(); ++i) {
+            const CallSummary& call_summary = function->get_call_summary(i);
+
+            dyn_behavior_data_table_->write_row(
+                function->get_id(),
+                function->get_namespace(),
+                names,
+                sexptype_to_string(function->get_type()),
+                function->get_formal_parameter_count(),
+                call_summary.is_S3_method(),
+                call_summary.is_S4_method(),
+                sexptype_to_string(call_summary.get_return_value_type()),
+                call_summary.get_call_count(),
+                call_summary.get_dyn_call_count());
+        }
     }
 
     void serialize_function_call_summary_(const Function* function,
@@ -1027,8 +1103,7 @@ class TracerState {
                     call_summary.get_missing_argument_positions()),
                 sexptype_to_string(call_summary.get_return_value_type()),
                 call_summary.is_jumped(),
-                call_summary.get_call_count(),
-                call_summary.get_call_arg_count());
+                call_summary.get_call_count());
         }
     }
 

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -72,6 +72,15 @@ void closure_entry(dyntracer_t* dyntracer,
   //     while(loopy);
   // }
 
+  std::string function_name = function_call->get_function_name();
+  if (function_name.compare("assign") == 0) {
+      state.process_dynamic_calls_for_closures(
+          function_name, function_call, 1);
+  } else if (function_name.compare("with") == 0) {
+      state.process_dynamic_calls_for_closures(
+          function_name, function_call, 1);
+  }
+
   set_dispatch(function_call, dispatch);
 
   state.push_stack(function_call);
@@ -165,6 +174,11 @@ void special_entry(dyntracer_t* dyntracer,
   state.enter_probe(Event::SpecialEntry);
 
   Call* function_call = state.create_call(call, op, args, rho);
+
+  std::string function_name = function_call->get_function_name();
+  if (function_name.compare("<<-") == 0) {
+      state.process_dynamic_calls_for_specials(function_call);
+  }
 
   set_dispatch(function_call, dispatch);
 


### PR DESCRIPTION
* Fixed the profiling for the cases where the parameter was a call to function(){}, for assign, <<- and with
* Moved the processing to the TracerState class rather than keeping it in the Call class
* Changed the name of the counters (call_arg_count to dyn_call_count) to make them hopefully more understandable
