### PR TITLE
update the dyn call counter properly for the first call

### DIFF
--- a/src/CallSummary.h
+++ b/src/CallSummary.h
@@ -13,7 +13,7 @@ class CallSummary {
         S3_method_ = call->is_S3_method();
         S4_method_ = call->is_S4_method();
         call_count_ = 1;
-        dyn_call_count_ = 0;
+        dyn_call_count_ = call->is_dyn_call();
     }
 
     const pos_seq_t& get_force_order() const {


### PR DESCRIPTION
dyn call count was 0 when a new CallSummary was instantiated. This led to wrong results as the first call initiating the creation of the summary can be a dynamic call.