### PR TITLE
Trace superassign and assign via environment hooks

### DIFF
--- a/src/AssignmentState.h
+++ b/src/AssignmentState.h
@@ -1,0 +1,41 @@
+#ifndef DYNAMISMTRACER_ASSIGNMENT_STATE_H
+#define DYNAMISMTRACER_ASSIGNMENT_STATE_H
+
+#include "Rinternals.h"
+
+class AssignmentState {
+  public:
+    /* defined in cpp file to get around cyclic dependency issues. */
+    explicit AssignmentState(const SEXP symbol,
+                    const SEXP environment,
+                    const sexptype_t type,
+                    const SEXP calling_environment):
+                symbol_(symbol),
+                environment_(environment),
+                type_(type),
+                calling_environment_(calling_environment) {}
+
+    const SEXP get_symbol() const {
+        return symbol_;
+    }
+
+    const SEXP get_environment() const {
+        return environment_;
+    };
+
+    const SEXP get_calling_environment() const {
+      return calling_environment_;
+    }
+
+    const sexptype_t get_type() const {
+      return type_;
+    }
+
+  private:
+    const SEXP symbol_;
+    const SEXP environment_;
+    const sexptype_t type_;
+    const SEXP calling_environment_;
+};
+
+#endif /* DYNAMISMTRACER_ASSIGNMENT_STATE_H */

--- a/src/Function.h
+++ b/src/Function.h
@@ -121,6 +121,10 @@ class Function {
         return (get_primitive_offset() == PRIMITIVE_SUPER_ASSIGN_OFFSET_);
     }
 
+    bool is_fast_subassign() const {
+        return (get_primitive_offset() == PRIMITIVE_FAST_SUBASSIGN_OFFSET_);
+    }
+
     const function_id_t& get_id() const {
         return id_;
     }
@@ -214,6 +218,7 @@ class Function {
     static const int PRIMITIVE_LEFT_ASSIGN_OFFSET_ = 8;
     static const int PRIMITIVE_EQUAL_ASSIGN_OFFSET_ = 9;
     static const int PRIMITIVE_SUPER_ASSIGN_OFFSET_ = 10;
+    static const int PRIMITIVE_FAST_SUBASSIGN_OFFSET_ = 20;
     static const int PRIMITIVE_RETURN_OFFSET_ = 6;
     static const int PRIMITIVE_CURLY_BRACKET_OFFSET_ = 11;
     static const int PRIMITIVE_DOT_INTERNAL_OFFSET_ = 26;

--- a/src/TracerState.h
+++ b/src/TracerState.h
@@ -1339,25 +1339,39 @@ class TracerState {
     std::vector<unsigned int> object_count_;
     std::vector<std::pair<lifecycle_t, int>> lifecycle_summary_;
     std::vector<unsigned long int> event_counter_;
-
     std::vector<AssignmentState> assignment_stack_;
     
 public: 
-  void push_assignment_stack(SEXP symbol, SEXP env, sexptype_t type, SEXP calling_env) {
-    assignment_stack_.push_back(AssignmentState(symbol,env, type, calling_env));
-  }
-  
-  AssignmentState& peek_assignment_stack() {
-    return assignment_stack_[assignment_stack_.size() - 1];
-  }
-  
-  bool assignment_stack_is_empty() {
-    return assignment_stack_.size() == 0;
-  }
 
-void pop_assignment_stack() {
-    assignment_stack_.pop_back();
-  }
+    bool is_fresh_environment(SEXP rho) {
+        ExecutionContextStack& stack = get_stack_();
+        bool fresh = true;
+
+        for (auto iter = stack.rbegin(); iter != stack.rend(); ++iter) {
+            ExecutionContext& exec_ctxt = *iter;
+            if (!exec_ctxt.is_r_context()) {
+                fresh = fresh && (exec_ctxt.get_call()->get_environment() != rho); 
+            }
+        }
+        return fresh;
+    }
+
+
+    void push_assignment_stack(SEXP symbol, SEXP env, sexptype_t type, SEXP calling_env) {
+        assignment_stack_.push_back(AssignmentState(symbol,env, type, calling_env));
+    }
+    
+    AssignmentState& peek_assignment_stack() {
+        return assignment_stack_[assignment_stack_.size() - 1];
+    }
+    
+    bool assignment_stack_is_empty() {
+        return assignment_stack_.size() == 0;
+    }
+
+    void pop_assignment_stack() {
+        assignment_stack_.pop_back();
+    }
   
   
 };

--- a/src/TracerState.h
+++ b/src/TracerState.h
@@ -279,6 +279,7 @@ class TracerState {
         delete call_summaries_data_table_;
         delete dynamic_call_summaries_data_table_;
         delete function_definitions_data_table_;
+        delete dynamic_function_definitions_data_table_;
         delete arguments_data_table_;
         delete side_effects_data_table_;
         delete promises_data_table_;

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -369,6 +369,7 @@ void environment_variable_define(dyntracer_t* dyntracer,
   if ((!state.assignment_stack_is_empty())
   and (state.peek_assignment_stack().get_symbol() == symbol)
   and (state.peek_assignment_stack().get_calling_environment() != rho)
+  and (!state.is_fresh_environment(rho))
   and (type_of_sexp(value) == CLOSXP))    
   {
       sexptype_t type = state.peek_assignment_stack().get_type();
@@ -404,6 +405,7 @@ void environment_variable_assign(dyntracer_t* dyntracer,
     if ((!state.assignment_stack_is_empty())
     and (state.peek_assignment_stack().get_symbol() == symbol)
     and (state.peek_assignment_stack().get_calling_environment() != rho)
+    and (!state.is_fresh_environment(rho))
     and (type_of_sexp(value) == CLOSXP)) 
     {
       sexptype_t type = state.peek_assignment_stack().get_type();

--- a/src/probes.h
+++ b/src/probes.h
@@ -72,5 +72,24 @@ void context_jump(dyntracer_t* dyntracer,
                   int restart);
 
 void context_exit(dyntracer_t* dyntracer, const RCNTXT*);
+
+void environment_variable_define(dyntracer_t* dyntracer,
+                                 const SEXP symbol,
+                                 const SEXP value,
+                                 const SEXP rho);
+
+void environment_variable_assign(dyntracer_t* dyntracer,
+                                 const SEXP symbol,
+                                 const SEXP value,
+                                 const SEXP rho);
+
+void environment_variable_remove(dyntracer_t* dyntracer,
+                                 const SEXP symbol,
+                                 const SEXP rho);
+
+void environment_variable_lookup(dyntracer_t* dyntracer,
+                                 const SEXP symbol,
+                                 const SEXP value,
+                                 const SEXP rho);
 };
 #endif /* DYNAMISMTRACER_PROBES_H */

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -32,6 +32,10 @@ SEXP create_dyntracer(SEXP output_dirpath,
     dyntracer->probe_context_entry = context_entry;
     dyntracer->probe_context_jump = context_jump;
     dyntracer->probe_context_exit = context_exit;
+    dyntracer->probe_environment_variable_define = environment_variable_define;
+    dyntracer->probe_environment_variable_assign = environment_variable_assign;
+    dyntracer->probe_environment_variable_remove = environment_variable_remove;
+    dyntracer->probe_environment_variable_lookup = environment_variable_lookup;
     return dyntracer_to_sexp(dyntracer, "dyntracer.promise");
 }
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -41,6 +41,10 @@ bool sexp_to_bool(SEXP value) {
     return LOGICAL(value)[0] == TRUE;
 }
 
+SEXP strsxp_to_sym(SEXP value) {
+    return Rf_install(CHAR(asChar(value)));
+}
+
 int sexp_to_int(SEXP value) {
     return (int) *INTEGER(value);
 }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -12,6 +12,8 @@ char* copy_string(char* destination, const char* source, size_t buffer_size);
 
 bool sexp_to_bool(SEXP value);
 
+SEXP strsxp_to_sym(SEXP value);
+
 int sexp_to_int(SEXP value);
 
 std::string sexp_to_string(SEXP value);


### PR DESCRIPTION
Move the tracing to the probes file
Add a new function definition table for dynamic calls
exclude subassign from being dynamic